### PR TITLE
added Makevars file with Rcpp settings

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,14 @@
+
+## With R 3.1.0 or later, you can uncomment the following line to tell R to 
+## enable compilation with C++11 (where available)
+##
+## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
+## availability of the package we do not yet enforce this here.  It is however
+## recommended for client packages to set it.
+##
+## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
+## support within Armadillo prefers / requires it
+CXX_STD = CXX11
+
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,14 @@
+
+## With R 3.1.0 or later, you can uncomment the following line to tell R to 
+## enable compilation with C++11 (where available)
+##
+## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
+## availability of the package we do not yet enforce this here.  It is however
+## recommended for client packages to set it.
+##
+## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
+## support within Armadillo prefers / requires it
+CXX_STD = CXX11
+
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
Hi, 

I cannot install your package on my computer (Ubuntu 18.04 with Rstudio, R and all packages up-to-date). I have a linking problem during the load of the package:

```
** testing if installed package can be loaded
Error: package or namespace load failed for ‘MCMVR’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/home/jchiquet/R/x86_64-pc-linux-gnu-library/3.5/MCMVR/libs/MCMVR.so':
  /home/jchiquet/R/x86_64-pc-linux-gnu-library/3.5/MCMVR/libs/MCMVR.so: undefined symbol: dpotrf_
Error: loading failed
Execution halted
ERROR: loading failed
* removing ‘/home/jchiquet/R/x86_64-pc-linux-gnu-library/3.5/MCMVR’
```

I think you forgot the standard Makevars files required when using RcppArmadillo package: it can be obtained via the `RcppArmadillo.package.skeleton()`R function.

I forked you repository to do so and it seems to work (at least I can install via install_github("jchiquet/MCMVR"))
